### PR TITLE
Feature/logging

### DIFF
--- a/command-tests/src/main/java/com/github/fhtw/swp/tutorium/command/CommandTest.java
+++ b/command-tests/src/main/java/com/github/fhtw/swp/tutorium/command/CommandTest.java
@@ -5,7 +5,7 @@ import cucumber.api.junit.Cucumber;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(plugin = {"cucumber.runtime.ScenarioStatsSummaryPrinter", "junit:results/command_results.xml"})
+@CucumberOptions(plugin = {"cucumber.runtime.ScenarioStatsSummaryPrinter", "junit:results/command_results.xml", "com.github.fhtw.swp.tutorium.common.LoggingReporter"})
 public class CommandTest {
 
 }

--- a/common/src/main/java/com/github/fhtw/swp/tutorium/common/LoggingReporter.java
+++ b/common/src/main/java/com/github/fhtw/swp/tutorium/common/LoggingReporter.java
@@ -1,0 +1,54 @@
+package com.github.fhtw.swp.tutorium.common;
+
+import gherkin.formatter.Reporter;
+import gherkin.formatter.model.Match;
+import gherkin.formatter.model.Result;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class LoggingReporter implements Reporter {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @Override
+    public void before(Match match, Result result) {
+        final Throwable error = result.getError();
+
+        if (error != null) {
+            LOGGER.error("", error);
+        }
+    }
+
+    @Override
+    public void result(Result result) {
+        final Throwable error = result.getError();
+
+        if (error != null) {
+            LOGGER.error("", error);
+        }
+    }
+
+    @Override
+    public void after(Match match, Result result) {
+        final Throwable error = result.getError();
+
+        if (error != null) {
+            LOGGER.error("", error);
+        }
+    }
+
+    @Override
+    public void match(Match match) {
+
+    }
+
+    @Override
+    public void embedding(String mimeType, byte[] data) {
+
+    }
+
+    @Override
+    public void write(String text) {
+
+    }
+}

--- a/common/src/main/java/com/github/fhtw/swp/tutorium/common/LoggingReporter.java
+++ b/common/src/main/java/com/github/fhtw/swp/tutorium/common/LoggingReporter.java
@@ -8,7 +8,8 @@ import org.apache.logging.log4j.Logger;
 
 public class LoggingReporter implements Reporter {
 
-    private static final Logger LOGGER = LogManager.getLogger();
+    private static final Logger LOGGER = LogManager.getLogger(LoggingReporter.class);
+    private static final Logger ASSERTION_FAILURES = LogManager.getLogger("AssertionFailures");
 
     @Override
     public void before(Match match, Result result) {
@@ -16,6 +17,10 @@ public class LoggingReporter implements Reporter {
 
         if (error != null) {
             LOGGER.error("", error);
+        }
+
+        if (error instanceof AssertionError) {
+            ASSERTION_FAILURES.info(error.getMessage());
         }
     }
 
@@ -26,6 +31,10 @@ public class LoggingReporter implements Reporter {
         if (error != null) {
             LOGGER.error("", error);
         }
+
+        if (error instanceof AssertionError) {
+            ASSERTION_FAILURES.info(error.getMessage());
+        }
     }
 
     @Override
@@ -34,6 +43,10 @@ public class LoggingReporter implements Reporter {
 
         if (error != null) {
             LOGGER.error("", error);
+        }
+
+        if (error instanceof AssertionError) {
+            ASSERTION_FAILURES.info(error.getMessage());
         }
     }
 

--- a/common/src/main/java/com/github/fhtw/swp/tutorium/common/matcher/MethodNamePrefixMatcher.java
+++ b/common/src/main/java/com/github/fhtw/swp/tutorium/common/matcher/MethodNamePrefixMatcher.java
@@ -20,11 +20,14 @@ public class MethodNamePrefixMatcher extends TypeSafeDiagnosingMatcher<Method> {
 
     @Override
     protected boolean matchesSafely(Method method, Description mismatchDescription) {
+
+        mismatchDescription.appendValue(method).appendText(" is named ").appendText(method.getName());
+
         return method.getName().startsWith(prefix);
     }
 
     @Override
     public void describeTo(Description description) {
-        
+        description.appendText("a method that starts with ").appendValue(prefix);
     }
 }

--- a/common/src/main/java/com/github/fhtw/swp/tutorium/common/matcher/OnlyInterfaceParametersMethodMatcher.java
+++ b/common/src/main/java/com/github/fhtw/swp/tutorium/common/matcher/OnlyInterfaceParametersMethodMatcher.java
@@ -1,12 +1,14 @@
 package com.github.fhtw.swp.tutorium.common.matcher;
 
-import com.google.common.collect.FluentIterable;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 
 public class OnlyInterfaceParametersMethodMatcher extends TypeSafeDiagnosingMatcher<Method> {
 
@@ -16,11 +18,24 @@ public class OnlyInterfaceParametersMethodMatcher extends TypeSafeDiagnosingMatc
 
     @Override
     protected boolean matchesSafely(Method item, Description mismatchDescription) {
-        return FluentIterable.from(Arrays.asList(item.getParameterTypes())).allMatch(Class::isInterface);
+
+        final List<Class<?>> nonInterfaceTypes = getNonInterfaceTypes(item);
+
+        mismatchDescription.appendValueList("(", ",", ")", nonInterfaceTypes).appendText(" are not interfaces");
+
+        return nonInterfaceTypes.isEmpty();
+    }
+
+    private List<Class<?>> getNonInterfaceTypes(Method item) {
+        return Arrays.stream(item.getParameterTypes()).filter(this::isNotInterface).collect(toList());
+    }
+
+    private boolean isNotInterface(Class<?> c) {
+        return !c.isInterface();
     }
 
     @Override
     public void describeTo(Description description) {
-
+        description.appendText("all parameters to be interfaces");
     }
 }

--- a/common/src/main/java/com/github/fhtw/swp/tutorium/common/matcher/ParameterCountMethodMatcher.java
+++ b/common/src/main/java/com/github/fhtw/swp/tutorium/common/matcher/ParameterCountMethodMatcher.java
@@ -20,11 +20,16 @@ public class ParameterCountMethodMatcher extends TypeSafeDiagnosingMatcher<Metho
 
     @Override
     protected boolean matchesSafely(Method item, Description mismatchDescription) {
-        return item.getParameterTypes().length == parameterCount;
+
+        final int actualParameterCount = item.getParameterTypes().length;
+
+        mismatchDescription.appendValue(item).appendText(" has ").appendValue(actualParameterCount).appendText(" parameters");
+
+        return actualParameterCount == parameterCount;
     }
 
     @Override
     public void describeTo(Description description) {
-
+        description.appendValue(parameterCount).appendText(" parameters");
     }
 }

--- a/common/src/main/java/com/github/fhtw/swp/tutorium/common/matcher/PrivateConstructorMatcher.java
+++ b/common/src/main/java/com/github/fhtw/swp/tutorium/common/matcher/PrivateConstructorMatcher.java
@@ -16,6 +16,8 @@ public class PrivateConstructorMatcher extends TypeSafeDiagnosingMatcher<Class<?
 
         final Set<Constructor> allConstructors = ReflectionUtils.getAllConstructors(item);
 
+        mismatchDescription.appendValue(item).appendText(" has at least one non-private constructor");
+
         return allConstructors.stream().allMatch(this::isPrivate);
     }
 
@@ -25,6 +27,6 @@ public class PrivateConstructorMatcher extends TypeSafeDiagnosingMatcher<Class<?
 
     @Override
     public void describeTo(Description description) {
-
+        description.appendText("all constructors to be private");
     }
 }

--- a/common/src/main/java/com/github/fhtw/swp/tutorium/common/matcher/PrivateConstructorMatcher.java
+++ b/common/src/main/java/com/github/fhtw/swp/tutorium/common/matcher/PrivateConstructorMatcher.java
@@ -6,7 +6,10 @@ import org.reflections.ReflectionUtils;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.util.List;
 import java.util.Set;
+
+import static java.util.stream.Collectors.toList;
 
 @SuppressWarnings("unchecked")
 public class PrivateConstructorMatcher extends TypeSafeDiagnosingMatcher<Class<?>> {
@@ -16,13 +19,20 @@ public class PrivateConstructorMatcher extends TypeSafeDiagnosingMatcher<Class<?
 
         final Set<Constructor> allConstructors = ReflectionUtils.getAllConstructors(item);
 
-        mismatchDescription.appendValue(item).appendText(" has at least one non-private constructor");
+        final List<Constructor> nonPrivateConstructors = allConstructors.stream().filter(this::isNotPrivate).collect(toList());
 
-        return allConstructors.stream().allMatch(this::isPrivate);
+        mismatchDescription
+                .appendText("constructors ")
+                .appendValueList("(", ",", ")", nonPrivateConstructors)
+                .appendText(" in class ")
+                .appendValue(item)
+                .appendText(" are not private");
+
+        return nonPrivateConstructors.isEmpty();
     }
 
-    private boolean isPrivate(Constructor ctor) {
-        return Modifier.isPrivate(ctor.getModifiers());
+    private boolean isNotPrivate(Constructor ctor) {
+        return !Modifier.isPrivate(ctor.getModifiers());
     }
 
     @Override

--- a/observer-tests/src/main/java/com/github/fhtw/swp/tutorium/observer/ObserverTest.java
+++ b/observer-tests/src/main/java/com/github/fhtw/swp/tutorium/observer/ObserverTest.java
@@ -5,7 +5,7 @@ import cucumber.api.junit.Cucumber;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(plugin = {"cucumber.runtime.ScenarioStatsSummaryPrinter", "junit:results/observer_results.xml"})
+@CucumberOptions(plugin = {"cucumber.runtime.ScenarioStatsSummaryPrinter", "junit:results/observer_results.xml", "com.github.fhtw.swp.tutorium.common.LoggingReporter"})
 public class ObserverTest {
 
 }

--- a/singleton-tests/src/main/java/com/github/fhtw/swp/tutorium/singleton/SingletonTest.java
+++ b/singleton-tests/src/main/java/com/github/fhtw/swp/tutorium/singleton/SingletonTest.java
@@ -5,6 +5,6 @@ import cucumber.api.junit.Cucumber;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(plugin = {"cucumber.runtime.ScenarioStatsSummaryPrinter", "junit:results/singleton_results.xml"})
+@CucumberOptions(plugin = {"cucumber.runtime.ScenarioStatsSummaryPrinter", "junit:results/singleton_results.xml", "com.github.fhtw.swp.tutorium.common.LoggingReporter"})
 public class SingletonTest {
 }

--- a/singleton-tests/src/main/java/com/github/fhtw/swp/tutorium/singleton/matcher/FieldSingletonMatcher.java
+++ b/singleton-tests/src/main/java/com/github/fhtw/swp/tutorium/singleton/matcher/FieldSingletonMatcher.java
@@ -22,11 +22,13 @@ public class FieldSingletonMatcher extends TypeSafeDiagnosingMatcher<Class<?>> {
                 Singletons.FIELD.getPredicateFor(singletonClass)
         );
 
+        mismatchDescription.appendText("no fields in ").appendValue(singletonClass).appendText(" qualify for accessing the instance of a singleton");
+
         return !accessorFields.isEmpty();
     }
 
     @Override
     public void describeTo(Description description) {
-
+        description.appendText("a singleton that uses a field for accessing the instance");
     }
 }

--- a/singleton-tests/src/main/java/com/github/fhtw/swp/tutorium/singleton/matcher/MethodSingletonMatcher.java
+++ b/singleton-tests/src/main/java/com/github/fhtw/swp/tutorium/singleton/matcher/MethodSingletonMatcher.java
@@ -22,11 +22,13 @@ public class MethodSingletonMatcher extends TypeSafeDiagnosingMatcher<Class<?>> 
                 Singletons.METHOD.getPredicateFor(singletonClass)
         );
 
+        mismatchDescription.appendText("no methods in ").appendValue(singletonClass).appendText(" qualify for accessing the instance of a singleton");
+
         return !accessorMethods.isEmpty();
     }
 
     @Override
     public void describeTo(Description description) {
-
+        description.appendText("a singleton that uses a method for accessing the instance");
     }
 }

--- a/test-console/src/main/resources/log4j2.xml
+++ b/test-console/src/main/resources/log4j2.xml
@@ -11,10 +11,24 @@
                 <OnStartupTriggeringPolicy/>
             </Policies>
         </RollingFile>
+        <RollingFile name="assertion_failures"
+                     fileName="logs/assertion_failures.log"
+                     filePattern="logs/assertion_failures_%d{yyyy-MM-dd}_%i.log">
+            <PatternLayout>
+                <pattern>%m%n</pattern>
+            </PatternLayout>
+            <Policies>
+                <OnStartupTriggeringPolicy/>
+            </Policies>
+        </RollingFile>
     </Appenders>
     <Loggers>
         <Root level="DEBUG">
             <AppenderRef ref="SwpTestTool"/>
         </Root>
+
+        <Logger name="AssertionFailures" level="INFO" additivity="false">
+            <AppenderRef ref="assertion_failures"/>
+        </Logger>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Create a log-file upon every run of the tool containing all assertion errors. For example:

```
Expected: <0> parameters
     but: <public void org.example.MySubject.updateObservers(java.lang.Object)> has <1> parameters

Expected: all constructors to be private
     but: constructors (<public org.example.UselessSingleton()>,<public org.example.UselessSingleton(java.lang.Object)>) in class <class org.example.UselessSingleton> are not private

Expected: all parameters to be interfaces
     but: (<class org.example.Command>) are not interfaces
```
